### PR TITLE
types: make MockResolver recursive with ResolverMap

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -35,15 +35,8 @@ export type MockResolver<
   args?: TArgs,
   context?: TContext,
   info?: GraphQLResolveInfo,
-) => MockResolvedValue<TData> | ResolvedScalar
+) => MockResolvedValue<TData> | ResolvedScalar | ResolverMap
 
 export type ResolverMap<> = {
   [key: string]: MockResolver<any>
-} & {
-  Query?: {
-    [key: string]: MockResolver<any>
-  }
-  Mutation?: {
-    [key: string]: MockResolver<any>
-  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,4 +39,11 @@ export type MockResolver<
 
 export type ResolverMap<> = {
   [key: string]: MockResolver<any>
+} & {
+  Query?: {
+    [key: string]: MockResolver<any>
+  }
+  Mutation?: {
+    [key: string]: MockResolver<any>
+  }
 }


### PR DESCRIPTION
In projects with strict prohibitions against inferred `any` types, resolver maps that include `Query` or `Mutation` resolvers will result in type errors unless they are explicitly typed.

The following code results in a TypeScript error if you do not manually specify params and return types for the resolver

```typescript
  mocks: {
    Query: () => ({
      user: (_parent, args) => ({
        userId: args.userId,
      }),
    }),
  }
```

Error:
<img width="661" alt="image" src="https://user-images.githubusercontent.com/1006979/104244595-fa00ae00-541f-11eb-8366-416276d5b082.png">
